### PR TITLE
fix: load color theme before DOM is fully loaded

### DIFF
--- a/app/static/js/toggle_theme.js
+++ b/app/static/js/toggle_theme.js
@@ -1,27 +1,34 @@
-document.addEventListener("DOMContentLoaded", function() {
-  const themeIcons = {
-    "light": "🌞",
-    "dark": "🌚"
-  };
+const themeIcons = {
+  "light": "🌞",
+  "dark": "🌚"
+};
 
-  // Detect theme: from storage or from system
-  let theme = localStorage.getItem('theme');
-  if (!theme) {
-    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light";
-    localStorage.setItem('theme', theme);
+function setTheme(theme) {
+  document.body.classList.remove("theme-light", "theme-dark");
+  document.body.classList.add("theme-" + theme);
+  const themeLabel = document.getElementById("theme-label");
+  if (themeLabel) {
+    themeLabel.textContent = themeIcons[theme];
+  } else {
+    document.addEventListener("DOMContentLoaded", function () {
+      document.getElementById("theme-label").textContent = themeIcons[theme];
+    });
   }
-  setTheme(theme);
+}
 
-  document.getElementById("theme-toggle-btn").addEventListener("click", function() {
+// Detect theme: from storage or from system
+let theme = localStorage.getItem('theme');
+if (!theme) {
+  theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light";
+  localStorage.setItem('theme', theme);
+}
+setTheme(theme);
+
+document.addEventListener("DOMContentLoaded", function () {
+  document.getElementById("theme-toggle-btn").addEventListener("click", function () {
     theme = theme === "light" ? "dark" : "light";
     localStorage.setItem('theme', theme);
     setTheme(theme);
   });
-
-  function setTheme(theme) {
-    document.body.classList.remove("theme-light", "theme-dark");
-    document.body.classList.add("theme-" + theme);
-    document.getElementById("theme-label").textContent = themeIcons[theme];
-  }
 });
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,7 +16,6 @@
   {% endblock links %}
   <script>{% block script %}{% endblock script %}</script>
   <script src="{% static 'js/show_messages.js' %}"></script>
-  <script src="{% static 'js/toggle_theme.js' %}"></script>
   <script src="{% static 'js/foolproof_deletion.js' %}"></script>
   <script src="{% static 'js/modal_window_interactions.js' %}"></script>
   <script src="{% static 'js/mobile_layout.js' %}"></script>
@@ -28,6 +27,7 @@
   <title>TagMate - {% block title %}{% endblock title %}</title>
 </head>
 <body>
+<script src="{% static 'js/toggle_theme.js' %}"></script>
 <script>
   (function () {
     var tab = localStorage.getItem('blockL_selected_tab') || 'posts';


### PR DESCRIPTION
This PR moves code around to apply the theme-dark or theme-light to body right after `<body>` is inserted, instead of waiting for the entire DOM to load.

### Bug explanation
The code that applies the theme was called on `DOMContentLoaded` event, so after all the HTML elements are loaded. That resulted in `body` being without the proper `theme-...` class for a while, which worked fine for `light` theme (due to the fallback theme being light), but creating flashing for `dark`.

### Solution
1. In `toggle_theme.js`, setting the theme functionality is moved from under the `DOMContentLoaded` event to the top level.
    * This is to ensure this code runs right after this script file is loaded, without waiting for the entire DOM to load.
2. The `script` tag loading `toggle_theme.js` is moved to be the first child of `body` to ensure it only runs when `body` is already available in DOM.
    * We need `body` to be in DOM because the `theme-...` class has to be applied to `body`.

This is the easiest solution for this problem.
A slightly more maintainable approach would be to implement a `waitForElement` function that would return the `body` element when it's in DOM (but not before), and to call the code then. Example can be found in [this article](https://medium.com/@ryan_forrester_/javascript-wait-for-element-to-exist-simple-explanation-1cd8c569e354#4fd1).

I went with the least code approach.