### PR TITLE
chore: make textarea bigger by default + add placeholder

### DIFF
--- a/app/posts/static/posts/css/post_editor_style.css
+++ b/app/posts/static/posts/css/post_editor_style.css
@@ -352,7 +352,7 @@ input.add-tags-input:focus {
 textarea.edit-like-text {
   width: calc(100% - 2 * var(--input-text-padding));
   resize: none;
-  min-height: 315px;
+  min-height: calc((100vh - 2 * var(--padding) - 2 * var(--content-nested-padding) - var(--header-height)) / 3);
   font-size: var(--text-size-M1);
   field-sizing: content;
 }

--- a/app/posts/static/posts/css/post_editor_style.css
+++ b/app/posts/static/posts/css/post_editor_style.css
@@ -339,7 +339,6 @@ input.add-tags-input:focus {
   font: inherit;
   padding: var(--input-text-padding);
   margin: 0;
-  overflow: hidden !important;
   border-radius: var(--border-radius-S);
   color: var(--text-muted);
 }

--- a/app/posts/static/posts/css/post_editor_style.css
+++ b/app/posts/static/posts/css/post_editor_style.css
@@ -352,8 +352,9 @@ input.add-tags-input:focus {
 textarea.edit-like-text {
   width: calc(100% - 2 * var(--input-text-padding));
   resize: none;
-  min-height: 115px;
+  min-height: 315px;
   font-size: var(--text-size-M1);
+  field-sizing: content;
 }
 
 input.edit-like-text {

--- a/app/posts/templates/posts/post_editor.html
+++ b/app/posts/templates/posts/post_editor.html
@@ -326,8 +326,7 @@
               <button id="update-post-desc-btn" class="update-btn">Save!</button>
               <label>
                 <input type="hidden" name="action" value="update_post_desc">
-                <textarea type="text" class="edit-like-text submit-on-blur"
-                          oninput="auto_grow(this)" id="post-desc"
+                <textarea type="text" class="edit-like-text submit-on-blur" id="post-desc"
                           name="post_desc" placeholder="Your post description goes here...">{{ current_post.description }}</textarea>
               </label>
             </form>

--- a/app/posts/templates/posts/post_editor.html
+++ b/app/posts/templates/posts/post_editor.html
@@ -328,7 +328,7 @@
                 <input type="hidden" name="action" value="update_post_desc">
                 <textarea type="text" class="edit-like-text submit-on-blur"
                           oninput="auto_grow(this)" id="post-desc"
-                          name="post_desc" placeholder="">{{ current_post.description }}</textarea>
+                          name="post_desc" placeholder="Your post description goes here...">{{ current_post.description }}</textarea>
               </label>
             </form>
 

--- a/app/posts/templates/posts/post_editor.html
+++ b/app/posts/templates/posts/post_editor.html
@@ -337,7 +337,7 @@
               {% endfor %}
             </div>
           </div>
-          <button type="button" onclick="copyPreviewText()">Copy as Plain Text</button>
+          <button type="button" id="copy-preview-btn" onclick="copyPreviewText()">Copy as Plain Text</button>
         {% else %}
           <div class="empty-state-text">
             <span class="highlighted-text">Post preview</span> will appear here

--- a/app/posts/templates/posts/post_editor.html
+++ b/app/posts/templates/posts/post_editor.html
@@ -327,7 +327,8 @@
               <label>
                 <input type="hidden" name="action" value="update_post_desc">
                 <textarea type="text" class="edit-like-text submit-on-blur" id="post-desc"
-                          name="post_desc" placeholder="Your post description goes here...">{{ current_post.description }}</textarea>
+                          oninput="setTextAreaHeight(this)" name="post_desc"
+                          placeholder="Your post description goes here...">{{ current_post.description }}</textarea>
               </label>
             </form>
 

--- a/app/static/css/custom_style.css
+++ b/app/static/css/custom_style.css
@@ -29,7 +29,7 @@ body {
 }
 
 .content-main {
-  height: calc(100% - 50px);
+  height: calc(100% - var(--header-height));
   width: 100%;
   background-color: var(--bg-dark);
   overflow: auto;
@@ -56,7 +56,7 @@ body {
   color: whitesmoke;
   background-color: #173c61;
   align-items: center;
-  height: 50px;
+  height: var(--header-height);
   display: flex;
   padding: 0 30px;
   justify-content: space-between;

--- a/app/static/css/general_style.css
+++ b/app/static/css/general_style.css
@@ -136,7 +136,8 @@ body.theme-dark {
   color: var(--text-muted);
 }
 
-input[type="text"]::placeholder {
+input[type="text"]::placeholder,
+textarea::placeholder {
   color: var(--text-dimmed);
 }
 

--- a/app/static/css/general_style.css
+++ b/app/static/css/general_style.css
@@ -13,6 +13,7 @@
   --block-L-min-width: 16rem;
   --content-nested-padding: 1.25rem;
   --outline-width: 1px;
+  --header-height: 50px;
 
   font-size: 16px;
   --border-light: oklch(0.75 0.11 239.74);

--- a/app/static/js/auto_grow_text_inputs.js
+++ b/app/static/js/auto_grow_text_inputs.js
@@ -2,9 +2,11 @@ const sum = (array) => array.reduce((a, b) => a + b, 0);
 const toNumber = (array) => array.map(m => parseFloat(m) || 0);
 
 const setTextAreaHeight = (textarea) => {
-  if (textarea.innerHTML) {
-    textarea.style.height = '5px';
-    textarea.style.height = `${textarea.scrollHeight}px`;
+  if (textarea.innerHTML && !isChrome) {
+    setTimeout(() => {
+      textarea.style.height = '5px';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }, 0);
   }
 };
 
@@ -33,7 +35,7 @@ const setTextAreaMaxHeight = (textarea) => {
     const maxHeight = parentHeight - parentPaddings - siblingsHeight - margins - textareaPaddings;
 
     textarea.style.maxHeight = `${maxHeight}px`;
-  }, 100);
+  }, 0);
 }
 
 const setTextAreaStyle = () => {
@@ -59,5 +61,5 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
-document.addEventListener('DOMContentLoaded', setTextAreaStyle);
+window.addEventListener('load', setTextAreaStyle);
 window.addEventListener('resize', setTextAreaStyle);

--- a/app/static/js/auto_grow_text_inputs.js
+++ b/app/static/js/auto_grow_text_inputs.js
@@ -1,16 +1,3 @@
-function autoGrow(element) {
-  if (element.innerHTML) {
-    element.style.height = `${element.scrollHeight}px`;
-  }
-}
-
-// Expand on page load for prefilled content
-// Use window.onload ensures all resources (including styles/fonts) loaded
-window.addEventListener('load', function () {
-  document.querySelectorAll('textarea').forEach(autoGrow);
-});
-
-
 document.addEventListener("DOMContentLoaded", function () {
   function autoResizeInput(input) {
     if (input.tagName !== "INPUT") return;

--- a/app/static/js/auto_grow_text_inputs.js
+++ b/app/static/js/auto_grow_text_inputs.js
@@ -1,25 +1,26 @@
-function auto_grow(element) {
-  element.style.height = "5px";
-  element.style.height = (element.scrollHeight) + "px";
+function autoGrow(element) {
+  if (element.innerHTML) {
+    element.style.height = `${element.scrollHeight}px`;
+  }
 }
 
 // Expand on page load for prefilled content
 // Use window.onload ensures all resources (including styles/fonts) loaded
-window.addEventListener('load', function() {
-  document.querySelectorAll('textarea').forEach(auto_grow);
+window.addEventListener('load', function () {
+  document.querySelectorAll('textarea').forEach(autoGrow);
 });
 
 
 document.addEventListener("DOMContentLoaded", function () {
-    function autoResizeInput(input) {
-        if (input.tagName !== "INPUT") return;
-        input.style.width = "2ch"; // reset to minimum
-        input.style.width = (input.value.length + 1) + "ch";
-    }
-    document.querySelectorAll('.shrinkable-input').forEach(input => {
-        autoResizeInput(input);
-        input.addEventListener('input', function () {
-            autoResizeInput(input);
-        });
+  function autoResizeInput(input) {
+    if (input.tagName !== "INPUT") return;
+    input.style.width = "2ch"; // reset to minimum
+    input.style.width = (input.value.length + 1) + "ch";
+  }
+  document.querySelectorAll('.shrinkable-input').forEach(input => {
+    autoResizeInput(input);
+    input.addEventListener('input', function () {
+      autoResizeInput(input);
     });
+  });
 });

--- a/app/static/js/auto_grow_text_inputs.js
+++ b/app/static/js/auto_grow_text_inputs.js
@@ -1,33 +1,47 @@
 const sum = (array) => array.reduce((a, b) => a + b, 0);
 const toNumber = (array) => array.map(m => parseFloat(m) || 0);
 
-const setTextAreaMaxHeight = () => {
+const setTextAreaHeight = (textarea) => {
+  if (textarea.innerHTML) {
+    textarea.style.height = '5px';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }
+};
+
+const setTextAreaMaxHeight = (textarea) => {
+  setTimeout(() => {
+    const parentBlock = document.querySelector('.app-block-R');
+    const postPreviewTags = document.querySelector('#post-preview-tags');
+    const copyPreviewBtn = document.querySelector('#copy-preview-btn');
+    const postPreviewHeader = document.querySelector('.post-preview-header');
+
+    const { marginTop, marginBottom } = window.getComputedStyle(postPreviewTags);
+    const { paddingTop, paddingBottom } = window.getComputedStyle(textarea);
+    const {
+      paddingTop: parentPaddingTop,
+      paddingBottom: parentPaddingBottom,
+      gap: parentGap
+    } = window.getComputedStyle(parentBlock);
+
+    const margins = sum(toNumber([marginTop, marginBottom]));
+    const textareaPaddings = sum(toNumber([paddingTop, paddingBottom]));
+    const parentPaddings = sum(toNumber([parentPaddingTop, parentPaddingBottom, parentGap, parentGap]));
+
+    const parentHeight = parentBlock.clientHeight;
+    const siblingsHeight = (postPreviewTags?.clientHeight || 0) + (copyPreviewBtn?.clientHeight || 0) + (postPreviewHeader?.clientHeight || 0);
+
+    const maxHeight = parentHeight - parentPaddings - siblingsHeight - margins - textareaPaddings;
+
+    textarea.style.maxHeight = `${maxHeight}px`;
+  }, 100);
+}
+
+const setTextAreaStyle = () => {
   document.querySelectorAll('textarea.edit-like-text').forEach(textarea => {
-    setTimeout(() => {
-      const parentBlock = document.querySelector('.app-block-R');
-      const postPreviewTags = document.querySelector('#post-preview-tags');
-      const copyPreviewBtn = document.querySelector('#copy-preview-btn');
-      const postPreviewHeader = document.querySelector('.post-preview-header');
-
-      const { marginTop, marginBottom } = window.getComputedStyle(postPreviewTags);
-      const { paddingTop, paddingBottom } = window.getComputedStyle(textarea);
-      const {
-        paddingTop: parentPaddingTop,
-        paddingBottom: parentPaddingBottom,
-        gap: parentGap
-      } = window.getComputedStyle(parentBlock);
-
-      const margins = sum(toNumber([marginTop, marginBottom]));
-      const textareaPaddings = sum(toNumber([paddingTop, paddingBottom]));
-      const parentPaddings = sum(toNumber([parentPaddingTop, parentPaddingBottom, parentGap, parentGap]));
-
-      const parentHeight = parentBlock.clientHeight;
-      const siblingsHeight = (postPreviewTags?.clientHeight || 0) + (copyPreviewBtn?.clientHeight || 0) + (postPreviewHeader?.clientHeight || 0);
-
-      const maxHeight = parentHeight - parentPaddings - siblingsHeight - margins - textareaPaddings;
-
-      textarea.style.maxHeight = `${maxHeight}px`;
-    }, 100);
+    setTextAreaMaxHeight(textarea);
+    if (!isChrome) {
+      setTextAreaHeight(textarea);
+    }
   });
 }
 
@@ -45,5 +59,5 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
-document.addEventListener('DOMContentLoaded', setTextAreaMaxHeight);
-window.addEventListener('resize', setTextAreaMaxHeight);
+document.addEventListener('DOMContentLoaded', setTextAreaStyle);
+window.addEventListener('resize', setTextAreaStyle);

--- a/app/static/js/auto_grow_text_inputs.js
+++ b/app/static/js/auto_grow_text_inputs.js
@@ -1,3 +1,36 @@
+const sum = (array) => array.reduce((a, b) => a + b, 0);
+const toNumber = (array) => array.map(m => parseFloat(m) || 0);
+
+const setTextAreaMaxHeight = () => {
+  document.querySelectorAll('textarea.edit-like-text').forEach(textarea => {
+    setTimeout(() => {
+      const parentBlock = document.querySelector('.app-block-R');
+      const postPreviewTags = document.querySelector('#post-preview-tags');
+      const copyPreviewBtn = document.querySelector('#copy-preview-btn');
+      const postPreviewHeader = document.querySelector('.post-preview-header');
+
+      const { marginTop, marginBottom } = window.getComputedStyle(postPreviewTags);
+      const { paddingTop, paddingBottom } = window.getComputedStyle(textarea);
+      const {
+        paddingTop: parentPaddingTop,
+        paddingBottom: parentPaddingBottom,
+        gap: parentGap
+      } = window.getComputedStyle(parentBlock);
+
+      const margins = sum(toNumber([marginTop, marginBottom]));
+      const textareaPaddings = sum(toNumber([paddingTop, paddingBottom]));
+      const parentPaddings = sum(toNumber([parentPaddingTop, parentPaddingBottom, parentGap, parentGap]));
+
+      const parentHeight = parentBlock.clientHeight;
+      const siblingsHeight = (postPreviewTags?.clientHeight || 0) + (copyPreviewBtn?.clientHeight || 0) + (postPreviewHeader?.clientHeight || 0);
+
+      const maxHeight = parentHeight - parentPaddings - siblingsHeight - margins - textareaPaddings;
+
+      textarea.style.maxHeight = `${maxHeight}px`;
+    }, 100);
+  });
+}
+
 document.addEventListener("DOMContentLoaded", function () {
   function autoResizeInput(input) {
     if (input.tagName !== "INPUT") return;
@@ -11,3 +44,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 });
+
+document.addEventListener('DOMContentLoaded', setTextAreaMaxHeight);
+window.addEventListener('resize', setTextAreaMaxHeight);

--- a/app/static/js/browsers.js
+++ b/app/static/js/browsers.js
@@ -1,0 +1,16 @@
+// Opera 8.0+
+const isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+// Firefox 1.0+
+const isFirefox = typeof InstallTrigger !== 'undefined';
+// Safari 3.0+ "[object HTMLElementConstructor]" 
+const isSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && window['safari'].pushNotification));
+// Internet Explorer 6-11
+const isIE = /*@cc_on!@*/false || !!document.documentMode;
+// Edge 20+
+const isEdge = !isIE && !!window.StyleMedia;
+// Chrome 1 - 79
+const isChrome = !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime);
+// Edge (based on chromium) detection
+const isEdgeChromium = isChrome && (navigator.userAgent.indexOf("Edg") != -1);
+// Blink engine detection
+const isBlink = (isChrome || isOpera) && !!window.CSS;

--- a/app/static/js/mobile_layout.js
+++ b/app/static/js/mobile_layout.js
@@ -3,6 +3,9 @@ const toggleVisibleElement = (element, key) => {
   if (key) {
     const isVisible = element.classList.contains('visible');
     window.localStorage.setItem(key, isVisible.toString());
+    if (isVisible) {
+      setTextAreaMaxHeight();
+    }
   }
 };
 

--- a/app/static/js/mobile_layout.js
+++ b/app/static/js/mobile_layout.js
@@ -34,14 +34,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
   setPreviewStateFromLocalStorage(postPreview, 'preview');
 
-  postsMenuToggle.addEventListener('click', function () {
+  postsMenuToggle?.addEventListener('click', function () {
     togglePostsMenu(postsMenu, postsMenuToggle, defaultText);
   });
 
-  previewModeToggle.addEventListener('click', function () {
+  previewModeToggle?.addEventListener('click', function () {
     toggleVisibleElement(postPreview, 'preview');
   });
-  tagsModeToggle.addEventListener('click', function () {
+  tagsModeToggle?.addEventListener('click', function () {
     toggleVisibleElement(postPreview, 'preview');
   });
 });

--- a/app/static/js/mobile_layout.js
+++ b/app/static/js/mobile_layout.js
@@ -1,7 +1,14 @@
 const toggleVisibleElement = (element, key) => {
   element.classList.toggle('visible');
   if (key) {
-    window.localStorage.setItem(key, element.classList.contains('visible') ? 'true' : 'false');
+    const isVisible = element.classList.contains('visible');
+    window.localStorage.setItem(key, isVisible ? 'true' : 'false');
+    if (key === 'preview' && isVisible) {
+      setTimeout(() => {
+        const textarea = element.querySelector('textarea');
+        autoGrow(textarea);
+      }, 0);
+    }
   }
 };
 

--- a/app/static/js/mobile_layout.js
+++ b/app/static/js/mobile_layout.js
@@ -4,7 +4,7 @@ const toggleVisibleElement = (element, key) => {
     const isVisible = element.classList.contains('visible');
     window.localStorage.setItem(key, isVisible.toString());
     if (isVisible) {
-      setTextAreaMaxHeight();
+      setTextAreaStyle();
     }
   }
 };

--- a/app/static/js/mobile_layout.js
+++ b/app/static/js/mobile_layout.js
@@ -2,13 +2,7 @@ const toggleVisibleElement = (element, key) => {
   element.classList.toggle('visible');
   if (key) {
     const isVisible = element.classList.contains('visible');
-    window.localStorage.setItem(key, isVisible ? 'true' : 'false');
-    if (key === 'preview' && isVisible) {
-      setTimeout(() => {
-        const textarea = element.querySelector('textarea');
-        autoGrow(textarea);
-      }, 0);
-    }
+    window.localStorage.setItem(key, isVisible.toString());
   }
 };
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,6 +15,7 @@
   {% block links %}
   {% endblock links %}
   <script>{% block script %}{% endblock script %}</script>
+  <script src="{% static 'js/browsers.js' %}"></script>
   <script src="{% static 'js/show_messages.js' %}"></script>
   <script src="{% static 'js/foolproof_deletion.js' %}"></script>
   <script src="{% static 'js/modal_window_interactions.js' %}"></script>


### PR DESCRIPTION
1. Textarea min-height is set to 1/3 of the block.
2. Placeholder is added to the text area.
3. Textarea max-height is calculated after load and on resize, as to not to add scroll to `app-block-R`.