### PR TITLE
fix: make icon-btns larger on mobile screens

### DIFF
--- a/app/static/css/screen_sizes.css
+++ b/app/static/css/screen_sizes.css
@@ -52,6 +52,7 @@
 @media (width <= 64.4rem) {
   :root {
     --content-nested-padding: 0.375rem;
+    --icon-btn-height: 1.75rem;
   }
 
   .header {


### PR DESCRIPTION
Makes the `close item` and `delete item` icon buttons larger on smallest (mobile) screens.

### Before (1.5rem):
<img width="816" height="203" alt="Screenshot 2025-10-03 at 15 48 29" src="https://github.com/user-attachments/assets/68dd4983-fdfb-4f0f-91ba-d00d8b0f8069" />

### After (1.75rem):
<img width="816" height="202" alt="Screenshot 2025-10-03 at 15 48 17" src="https://github.com/user-attachments/assets/d9136c12-5600-4cc9-acc2-d235d3bf3806" />
