### PR TITLE
feat: sidebar overlay

### DIFF
--- a/app/posts/templates/posts/post_editor.html
+++ b/app/posts/templates/posts/post_editor.html
@@ -28,6 +28,7 @@
 
     <div id="app-main">
 
+      <div class="posts-menu-overlay small-screen-only" onclick="togglePostsMenu(this.nextElementSibling, this, document.querySelector('#nav-toggle-btn'))"></div>
       <div class="app-block app-block-L">
         <div class="tabs">
           <button id="tab-posts" class="tab-btn" type="button">Posts</button>

--- a/app/static/css/screen_sizes.css
+++ b/app/static/css/screen_sizes.css
@@ -1,6 +1,7 @@
 @media (width <= 1280px) {
   :root {
     --content-nested-padding: 0.8rem;
+    --transition-duration: 0.3s;
   }
 
   .small-screen-only {
@@ -49,21 +50,41 @@
   }
 
   #app-main > .app-block.app-block-L {
-    --dur: 0.3s;
     position: fixed;
     z-index: 10;
-    height: 100%;
+    height: calc(100% - var(--header-height));
     box-sizing: border-box;
     width: var(--block-L-min-width);
     min-width: var(--block-L-min-width);
     left: calc(-1 * var(--block-L-min-width));
     border-radius: 0;
     top: 50px;
-    transition: left var(--dur) ease;
+    transition: left var(--transition-duration) ease;
+  }
+
+  #app-main > .posts-menu-overlay {
+    display: none;
+    opacity: 0;
+    transition-property: opacity display;
+    transition-duration: var(--transition-duration);
+    transition-behavior: allow-discrete;
+    position: absolute;
+    top: calc(-1 * var(--content-nested-padding));
+    left: calc(-1 * var(--content-nested-padding));
+    bottom: calc(-1 * var(--content-nested-padding));
+    right: calc(-1 * var(--content-nested-padding));
+    background-color: rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(1px);
+    z-index: 10;
   }
 
   #app-main > .app-block-L.visible {
     left: 0;
+  }
+
+  #app-main > .posts-menu-overlay.visible {
+    display: block;
+    opacity: 1;
   }
 
   .header a {

--- a/app/static/js/mobile_layout.js
+++ b/app/static/js/mobile_layout.js
@@ -18,8 +18,9 @@ const setPreviewStateFromLocalStorage = (element, key) => {
   }
 }
 
-const togglePostsMenu = (postsMenu, postsMenuToggle) => {
+const togglePostsMenu = (postsMenu, postsMenuOverlay, postsMenuToggle) => {
   toggleVisibleElement(postsMenu);
+  toggleVisibleElement(postsMenuOverlay);
   const prevNavActive = document.querySelector('#nav-toggle-btn + a');
   if (postsMenu.classList.contains('visible')) {
     postsMenuToggle.classList.add('show-nav-back');
@@ -37,6 +38,7 @@ const togglePostsMenu = (postsMenu, postsMenuToggle) => {
 document.addEventListener("DOMContentLoaded", function () {
   const navToggleButton = document.querySelector('#nav-toggle-btn');
   const postsMenu = document.querySelector('.app-block-L');
+  const postsMenuOverlay = document.querySelector('.posts-menu-overlay');
   const previewModeToggle = document.querySelector('#preview-toggle');
   const tagsModeToggle = document.querySelector('#tags-toggle');
   const postPreview = document.querySelector('.post-preview');
@@ -44,7 +46,7 @@ document.addEventListener("DOMContentLoaded", function () {
   setPreviewStateFromLocalStorage(postPreview, 'preview');
 
   navToggleButton?.addEventListener('click', function () {
-    togglePostsMenu(postsMenu, navToggleButton);
+    togglePostsMenu(postsMenu, postsMenuOverlay, navToggleButton);
   });
 
   previewModeToggle?.addEventListener('click', function () {


### PR DESCRIPTION
Add blurred background when the sidebar is open on mobile

How to test:

1. On small screen, toggle posts/TGs sidebar.
2. Background should be blurred when sidebar is open.
3. Clicking outside of the sidebar (except for the header) should close the sidebar.