### PR TITLE
Set input length limits and fix UI issues

### DIFF
--- a/app/posts/models.py
+++ b/app/posts/models.py
@@ -24,6 +24,9 @@ HASHTAG_REGEX = (
     r'\U000024C2-\U0001F251'
     r']+$'
 )
+TG_NAME_MAX_LENGTH = 64
+POST_TITLE_MAX_LENGTH = 100
+POST_DESC_MAX_LENGTH = 5000
 
 hashtag_validator = RegexValidator(
     regex=HASHTAG_REGEX,
@@ -180,7 +183,7 @@ class TagGroup(TagOperationMixin):
     objects: models.Manager['TagGroup']
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='tag_groups')
-    name = StrippedCharField(max_length=64)
+    name = StrippedCharField(max_length=TG_NAME_MAX_LENGTH)
 
     tags = models.ManyToManyField(
         Tag,
@@ -221,8 +224,9 @@ class Post(TagOperationMixin):
     objects: models.Manager['Post']
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='posts')
-    title = StrippedCharField(max_length=100)
-    description = models.TextField(blank=True, validators=[MaxLengthValidator(5000)])
+    title = StrippedCharField(max_length=POST_TITLE_MAX_LENGTH)
+    description = models.TextField(blank=True,
+                                   validators=[MaxLengthValidator(POST_DESC_MAX_LENGTH)])
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/app/posts/static/posts/css/post_editor_style.css
+++ b/app/posts/static/posts/css/post_editor_style.css
@@ -63,7 +63,7 @@
 }
 
 /* Unified style for item-like objects */
-.tab-btn,
+button.tab-btn,
 .list-item {
   border-radius: var(--border-radius-S);
   cursor: pointer;
@@ -117,8 +117,8 @@
   padding-top: var(--outline-width);
 }
 
-.tab-btn:hover:not(.active),
-.list-inner .list-item:hover:not(.active) {
+button.tab-btn:hover,
+.list-inner .list-item:hover {
   box-shadow: 0 0 0 var(--outline-width) var(--primary-universal);
 }
 
@@ -388,11 +388,17 @@ input.edit-like-text {
 }
 
 /* common styles */
-.active {
+button.tab-btn.active,
+.list-item.active {
   font-weight: 400;
   background-color: var(--bg-light);
   box-shadow: 0 0 0 var(--outline-width) var(--border-light);
   color: var(--text);
+}
+
+.list-item.active:hover,
+.list-item.active:active {
+  box-shadow: 0 0 0 var(--outline-width) var(--border-light);
 }
 
 .list-item.active > .list-item-date {

--- a/app/posts/templates/posts/post_editor.html
+++ b/app/posts/templates/posts/post_editor.html
@@ -37,7 +37,8 @@
         <div id="recent-posts" class="list">
           {% if current_post %}
             <div class="list-item create-item-wrapper">
-              <button type="button" class="big-icon-btn create-item-btn" data-item-type="post" title="Create Post">
+              <button type="button" class="big-icon-btn create-item-btn" data-item-type="post"
+                      title="Create Post" data-max-length="{{ post_title_max_length }}">
                 {% include 'posts/buttons/add-circle-svgrepo-com.svg' %}
               </button>
               <div class="create-item-label">
@@ -75,7 +76,8 @@
         <div id="recent-tgs" class="list">
           {% if current_tg %}
             <div class="list-item create-item-wrapper">
-              <button type="button" class="big-icon-btn create-item-btn" data-item-type="taggroup" title="Create TagGroup">
+              <button type="button" class="big-icon-btn create-item-btn" data-item-type="taggroup"
+                      data-max-length="{{ tg_name_max_length }}" title="Create TagGroup">
                 {% include 'posts/buttons/add-circle-svgrepo-com.svg' %}
               </button>
               <div class="create-item-label">
@@ -143,7 +145,7 @@
                 <label>
                   <input type="hidden" name="action" value="update_post_title">
                   <input type="text" class="edit-like-text submit-on-blur shrinkable-input" id="post-title"
-                         name="post_title" placeholder="" enterkeyhint="send"
+                         name="post_title" placeholder="" enterkeyhint="send" maxlength="{{ post_title_max_length }}"
                          value="{{ current_post.title }}" required>
                 </label>
                 <button class="update-btn" id="update-post-title-btn">Update Title</button>
@@ -180,7 +182,8 @@
 
             {% else %}
               <div class="create-item-wrapper">
-                <button type="button" class="big-icon-btn create-item-btn" data-item-type="post" title="Create Post">
+                <button type="button" class="big-icon-btn create-item-btn" data-item-type="post"
+                        data-max-length="{{ post_title_max_length }}" title="Create Post">
                   {% include 'posts/buttons/add-circle-svgrepo-com.svg' %}
                 </button>
                 Create Post
@@ -235,7 +238,7 @@
                 {% csrf_token %}
                 <label>
                   <input type="hidden" name="action" value="update_tg">
-                  <input type="text" name="tg_name" placeholder=""
+                  <input type="text" name="tg_name" placeholder="" maxlength="{{ tg_name_max_length }}"
                          value="{{ current_tg.name }}" enterkeyhint="send"
                          id="tg-name" class="edit-like-text shrinkable-input submit-on-blur" required>
                 </label>
@@ -273,7 +276,8 @@
 
             {% else %}
               <div class="create-item-wrapper">
-                <button type="button" class="big-icon-btn create-item-btn" data-item-type="taggroup" title="Create TagGroup">
+                <button type="button" class="big-icon-btn create-item-btn" data-item-type="taggroup"
+                        data-max-length="{{ tg_name_max_length }}" title="Create TagGroup">
                   {% include 'posts/buttons/add-circle-svgrepo-com.svg' %}
                 </button>
                 Create TagGroup
@@ -327,7 +331,7 @@
               <label>
                 <input type="hidden" name="action" value="update_post_desc">
                 <textarea type="text" class="edit-like-text submit-on-blur" id="post-desc"
-                          oninput="setTextAreaHeight(this)" name="post_desc"
+                          oninput="setTextAreaHeight(this)" name="post_desc" maxlength="{{ post_desc_max_length }}"
                           placeholder="Your post description goes here...">{{ current_post.description }}</textarea>
               </label>
             </form>

--- a/app/posts/views.py
+++ b/app/posts/views.py
@@ -7,7 +7,11 @@ from django.views.decorators.http import require_POST
 from django.http import JsonResponse
 import json
 
-from posts.models import Post, Tag, TagGroup, generate_unique_tg_name as gen_tg_name
+from posts.models import (Post, Tag, TagGroup,
+                          POST_TITLE_MAX_LENGTH,
+                          POST_DESC_MAX_LENGTH,
+                          TG_NAME_MAX_LENGTH,
+                          generate_unique_tg_name as gen_tg_name)
 
 
 def field_validation_sender(request, val_error: ValidationError):
@@ -173,6 +177,7 @@ def post_editor(request, post_pk=None, tg_pk=None):
                         current_post.full_clean()
                     except ValidationError as e:
                         field_validation_sender(request, e)
+                        request.session['post_desc'] = post_desc
                         return redirect(request.path)
                     current_post.save()
                     messages.success(request, f'Post {current_post.title} updated')
@@ -216,7 +221,10 @@ def post_editor(request, post_pk=None, tg_pk=None):
             'post_tags_to_attach': request.session.pop('post_tags_to_attach', ''),
             'tg_tags_to_attach': request.session.pop('tg_tags_to_attach', ''),
             'submitted_input_id': request.session.pop('submitted_input_id', ''),
-        })
+            'post_title_max_length': POST_TITLE_MAX_LENGTH,
+            'tg_name_max_length': TG_NAME_MAX_LENGTH,
+            'post_desc_max_length': POST_DESC_MAX_LENGTH,
+    })
 
     return render(
         request,

--- a/app/static/js/modal_window_interactions.js
+++ b/app/static/js/modal_window_interactions.js
@@ -24,6 +24,12 @@ document.addEventListener('DOMContentLoaded', function() {
         default: "create_item"
     };
 
+    const MAX_LENGTH = {
+        post: "100",
+        taggroup: "64",
+        default: "100"
+    }
+
     document.querySelectorAll('.create-item-btn').forEach(btn => {
         btn.addEventListener('click', function(evt) {
             evt.preventDefault();
@@ -32,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // Look for a custom message or type
             let type = btn.getAttribute('data-item-type');
+            let maxLength = btn.getAttribute('data-max-length');
+
             let custom = modalText.textContent;
             modalText.textContent = MESSAGES[type] || custom || MESSAGES.default;
 
@@ -47,6 +55,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (titleInput) {
                     titleInput.focus();
                     titleInput.placeholder = PLACEHOLDERS[type] || PLACEHOLDERS.default;
+                    titleInput.maxLength = maxLength || MAX_LENGTH[type] || MAX_LENGTH.default;
                 }
             }
         });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,7 +68,7 @@
       </button>
     </div>
     {% block header-filter %}
-      <a href="https://github.com/serious-pavel/personal_site" target="_blank">
+      <a href="https://github.com/serious-pavel/tagmate" target="_blank">
         {% include 'buttons/github-142-svgrepo-com.svg' %}
       </a>
       <a href="https://www.linkedin.com/in/pavel-makhnev/" target="_blank">


### PR DESCRIPTION

This pull request includes the following updates:

- Added `maxlength` properties to all input/textarea fields associated with item properties, matching the model limitations.
- Added an extra field on `create-item-btns` for modal windows to use length data from constants.
- Moved field properties into constants.
- Fixed the GitHub project link.
- Resolved UI issues:
  - Fixed appearance of tab buttons.
  - Corrected hover/active selectors for list items and similar elements.

Note: Instead of saving the textarea\input values in the field on error I limited the user in ability to send incorrect data. There no need to save incorrect data in the field on error, in my opinion.